### PR TITLE
Changed bucket name to an environment variable

### DIFF
--- a/api/helpers/minio.js
+++ b/api/helpers/minio.js
@@ -17,15 +17,7 @@ var minioClient = new minio.Client({
 
 // This is the list of known, valid buckets documents can be uploaded and downloaded from
 // Set from a system environment variable, if that's not available then defaults to 'uploads'
-if (process.env.MINIO_BUCKET_NAME) {
-  var BUCKETS = {
-    DOCUMENTS_BUCKET: process.env.MINIO_BUCKET_NAME
-  };
-} else {
-  var BUCKETS = {
-    DOCUMENTS_BUCKET: 'uploads'
-  };
-}
+var BUCKETS = (process.env.MINIO_BUCKET_NAME) ? { DOCUMENTS_BUCKET: process.env.MINIO_BUCKET_NAME } : { DOCUMENTS_BUCKET: 'uploads' };
 
 exports.BUCKETS = BUCKETS;
 

--- a/api/helpers/minio.js
+++ b/api/helpers/minio.js
@@ -15,10 +15,18 @@ var minioClient = new minio.Client({
   secretKey: process.env.MINIO_SECRET_KEY
 });
 
-// This is the list of known, valid buckets documents can be uploaded and downloaded from.
-var BUCKETS = {
-  DOCUMENTS_BUCKET: 'uploads'
-};
+// This is the list of known, valid buckets documents can be uploaded and downloaded from
+// Set from a system environment variable, if that's not available then defaults to 'uploads'
+if (process.env.MINIO_BUCKET_NAME) {
+  var BUCKETS = {
+    DOCUMENTS_BUCKET: process.env.MINIO_BUCKET_NAME
+  };
+} else {
+  var BUCKETS = {
+    DOCUMENTS_BUCKET: 'uploads'
+  };
+}
+
 exports.BUCKETS = BUCKETS;
 
 /**


### PR DESCRIPTION
As we can't use a bucket name of "uploads" across all storage backends, we should be able to define the bucket name via a system environment variable.  If not defined, defaults back to "uploads"