### PR TITLE
Duplicate id generation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ package-lock.json
 yarn-error.log
 yarn.lock
 debug.log
+output.txt
 
 # System Files
 .DS_Store

--- a/api/test/factories/factory_helper.js
+++ b/api/test/factories/factory_helper.js
@@ -1,6 +1,6 @@
 const canada = require('canada');
 const _ = require('lodash');
-const bsonObjectId = require('BSON').ObjectId;
+const bsonObjectId = require('bson').ObjectId;
 const mongTypes = require('mongoose').Types;
 let faker = require('faker/locale/en');
 
@@ -123,8 +123,20 @@ function hexaDecimal(count) {
 
 function generateSeededObjectId(value) {
     let oid = (typeof value === "undefined") ? hexaDecimal(24).toLocaleLowerCase() : value;
-    if (!bsonObjectId.isValid(oid)) throw "Invalid attempt to generate an ObjectID: '" + oid + "'"
+    if (!bsonObjectId.isValid(oid)) throw "Invalid attempt to generate an ObjectID: '" + oid + "'";
     return mongTypes.ObjectId(oid);
+}
+
+let index = 1;
+
+function getInc() {
+    return (index + 1) % 0xffffff;
+}
+
+// when generating multiple projects' worth of data we need seeds that follow a repeatable 
+// pattern when the generators are set to static but are distinct values in order to avoid collisions
+function generateDeterministicSeed(commonFactorySeed, parentId) {
+    return (commonFactorySeed * 1000000) + Number(parentId.toString().replace(/a|b|c|d|e|f/gi, "").substr(0, 5)) + getInc();
 }
 
 exports.faker = faker;
@@ -137,3 +149,5 @@ exports.getRandomExistingListElementName = getRandomExistingListElementName;
 exports.generateFakeLocationString = generateFakeLocationString;
 exports.generateEpicFormatPhoneNumber = generateEpicFormatPhoneNumber;
 exports.ObjectId = generateSeededObjectId;
+exports.getInc = getInc;
+exports.generateDeterministicSeed = generateDeterministicSeed;

--- a/api/test/factories/list_factory.js
+++ b/api/test/factories/list_factory.js
@@ -4,11 +4,10 @@ const List = require('../../helpers/models/list');
 let faker = require('faker/locale/en');
 
 const factoryName = List.modelName;
-
 const ListArray1 = require('../../../migrations_data/lists.js');
 const ListArray2 = require('../../../migrations_data/new_list_items.js');
 const ListArray3 = require('../../../migrations_data/newProjectPhaseListItems.js');
-const ListArray4 = require('../../../migrations_data/regionList.js');
+const ListArray4 = require('../../../migrations_data/regionlist.js');
 const allListEntries = [].concat(ListArray1).concat(ListArray2).concat(ListArray3).concat(ListArray4);
 
 let _allListsLookupDict = {};

--- a/api/test/factories/recent_activity_factory.js
+++ b/api/test/factories/recent_activity_factory.js
@@ -10,8 +10,13 @@ factory.define(factoryName, RecentActivity, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
   factory_helper.faker = faker;
 
-  let usersPool = (buildOptions.usersPool) ? buildOptions.usersPool : null;
-  let listsPool = (buildOptions.listsPool) ? buildOptions.listsPool : null;
+  let usersPool = (buildOptions.pipeline) ? 
+    (buildOptions.pipeline.users) ? buildOptions.pipeline.users : null :
+    (buildOptions.usersPool) ? buildOptions.usersPool : null;
+
+  let listsPool = (buildOptions.pipeline) ? 
+    (buildOptions.pipeline.lists) ? buildOptions.pipeline.lists : null :
+    (buildOptions.listsPool) ? buildOptions.listsPool : null;
   const headlineTypes = listsPool.filter(listEntry => "headlineType" === listEntry.type);
   
   let raType = faker.random.arrayElement(["News", "Public Comment Period"]);

--- a/api/test/generate.test.js
+++ b/api/test/generate.test.js
@@ -5,8 +5,7 @@ const test_helper = require('./test_helper');
 const factory_helper = require('./factories/factory_helper');
 const request = require('supertest');
 const nock = require('nock');
-const generate_helper = require("./generate_helper");
-const gh = generate_helper; // shorthand alias for brevity
+const gh = require("./generate_helper");
 
 describe('Generate Test Data', () => {
   let adminUser = factory_helper.generateFakePerson('Stanley', '', 'Adminington');
@@ -19,28 +18,37 @@ describe('Generate Test Data', () => {
   describe('Generate Projects', () => {
     test('Generator', done => {
       test_helper.dataGenerationSettings.then(genSettings => {
-        //console.log(genSettings);
+        gh.debug(genSettings);
 
         // Default is to not run the data generator when running global tests
         if (genSettings.generate) {
           console.log("Data Generation is on");
-          gh.generateEntireDatabase(usersData).then(generatedData =>{
+          gh.generateEntireDatabase(usersData).then(generatedData => {
             console.log(((genSettings.generate_consistent_data) ? "Consistent" : "Random") + " data generation " + ((genSettings.save_to_persistent_mongo) ? "saved" : "unsaved"));
             let projects = generatedData.projects;
-            // console.log('projects: [' + projects + ']');
+            gh.debug('projects: [' + projects + ']');
             let documents = generatedData.projectDocuments;
 
+            if (0 == projects.length) {
+              expect(1).toEqual(1);
+              done();
+            }
+
+            generatedData.report();
             projects.map((project) => {
-              const projectDocuments = documents.filter(document => document[0].project == project._id);
-              console.log('Project [id, name]: [' + project._id + ', ' + project.name + ']');
-              
-              projectDocuments.map((document) => {
-                // console.log('document: [' + document[0] + ']');
-                console.log('Document [id, project, documentFileName]: [' + document[0]._id + ', ' + document[0].project + ', ' + document[0].documentFileName + ']');
-              });
-              
+              gh.info('Project [id, name]: [' + project._id + ', ' + project.name + ']');
               expect(project._id).toEqual(jasmine.any(Object));
               expect(project.CELeadEmail).toEqual("eao.compliance@gov.bc.ca");
+              gh.debug("total documents.length = " + documents.length);
+              if (0 < documents.length) {
+                const projectDocuments = documents.filter(document => document.project == project._id);
+                gh.debug("projectDocuments.length = " + projectDocuments.length);
+                projectDocuments.map((p_document) => {
+                  // console.log('document: [' + document + ']');
+                  gh.info('Document [id, project, documentFileName]: [' + p_document._id + ', ' + p_document.project + ', ' + p_document.documentFileName + ']');
+                });
+              }
+              
               //TODO:: Check the outputted deterministic data fields against the database model.  Some fields will always have randomness so tests will have to be designed around that.
               
               done();

--- a/api/test/generate_helper.js
+++ b/api/test/generate_helper.js
@@ -23,8 +23,12 @@ const documentFactory = require("./factories/document_factory");
 const recentActivityFactory = require("./factories/recent_activity_factory");
 require('../helpers/models/user');
 require('../helpers/models/project');
-let ft = require('./factory_template');
-let gd = require('./generated_data');
+const ft = require('./factory_template');
+const gd = require('./generated_data');
+
+// logging levels
+let isInfoMode = false;
+let isDebugMode = false;
 
 // Used to generate random values in the range [0 to CeilingValue] for correspondingly named objects
 let generatorCeilings = {
@@ -73,7 +77,7 @@ function generateEntireDatabase(usersData) {
     // foreach Project, generate the Groups relating to it
     return new Promise(function(resolve, reject) {
       generateChildSets(pipeline.projects, pipeline.users, pipeline.lists, groupTemplate).then(groups => {
-        pipeline.groups = groups;
+        pipeline.groups = normalizeFactoryResults(groups);
         resolve(pipeline);
       });
     });
@@ -82,7 +86,7 @@ function generateEntireDatabase(usersData) {
     // foreach Project, generate the Comment Periods relating to it
     return new Promise(function(resolve, reject) {
       generateChildSets(pipeline.projects, pipeline.users, pipeline.lists, commentPeriodTemplate).then(commentPeriods => {
-        pipeline.commentPeriods = commentPeriods;
+        pipeline.commentPeriods = normalizeFactoryResults(commentPeriods);
         resolve(pipeline);
       });
     });
@@ -90,8 +94,8 @@ function generateEntireDatabase(usersData) {
   .then(pipeline => { 
     // foreach Comment Period, generate the Comments relating to it
     return new Promise(function(resolve, reject) {
-      generateChildSets(pipeline.commentPeriods, pipeline.users, pipeline.lists, commentTemplate).then(comments => {
-        pipeline.comments = comments;
+      generateChildSets(pipeline.commentPeriods, pipeline.users, pipeline.lists, commentTemplate).then(commentPeriodComments => {
+        pipeline.commentPeriodComments = normalizeFactoryResults(commentPeriodComments);
         resolve(pipeline);
       });
     });
@@ -99,8 +103,8 @@ function generateEntireDatabase(usersData) {
   .then(pipeline => { 
     // foreach Comment Period, generate the Documents relating to it
     return new Promise(function(resolve, reject) {
-        generateChildSetsUsingPipeline(pipeline.commentPeriods, pipeline, commentPeriodDocumentTemplate).then(commentPeriodDocuments => {
-        pipeline.commentPeriodDocuments = commentPeriodDocuments;
+      generateChildSetsUsingPipeline(pipeline.commentPeriods, pipeline, commentPeriodDocumentTemplate).then(commentPeriodDocuments => {
+        pipeline.commentPeriodDocuments = normalizeFactoryResults(commentPeriodDocuments);
         resolve(pipeline);
       });
     });
@@ -108,7 +112,7 @@ function generateEntireDatabase(usersData) {
     // foreach Project, generate the Documents relating to it
     return new Promise(function(resolve, reject) {
       generateChildSets(pipeline.projects, pipeline.users, pipeline.lists, projectDocumentTemplate).then(projectDocuments => {
-        pipeline.projectDocuments = projectDocuments;
+        pipeline.projectDocuments = normalizeFactoryResults(projectDocuments);
         resolve(pipeline);
       });
     });
@@ -116,7 +120,7 @@ function generateEntireDatabase(usersData) {
     // foreach Project Document, generate a possible Recent Actvity relating to it
     return new Promise(function(resolve, reject) {
       generateChildSets(pipeline.projectDocuments, pipeline.users, pipeline.lists, documentRecentActivitiesTemplate).then(recentActivities => {
-        pipeline.projectDocumentRecentActivities = recentActivities;
+        pipeline.projectDocumentRecentActivities = normalizeFactoryResults(recentActivities);
         resolve(pipeline);
       });
     });
@@ -124,7 +128,7 @@ function generateEntireDatabase(usersData) {
     // foreach Comment Period, generate a possible Recent Actvity relating to it
     return new Promise(function(resolve, reject) {
       generateChildSetsUsingPipeline(pipeline.commentPeriods, pipeline, commentPeriodRecentActivitiesTemplate).then(recentActivities => {
-        pipeline.commentPeriodRecentActivities = recentActivities;
+        pipeline.commentPeriodRecentActivities = normalizeFactoryResults(recentActivities);
         resolve(pipeline);
       });
     });
@@ -132,6 +136,7 @@ function generateEntireDatabase(usersData) {
 };
 
 function generateGroupSetForProject(factoryKey, project, buildOptions, groupsToGen) {
+  console.debug("groupsToGen = " + groupsToGen);
   return new Promise(function(resolve, reject) {
     let customGroupSettings = { project: factory_helper.ObjectId(project._id) };
     factory.createMany(factoryKey, groupsToGen, customGroupSettings, buildOptions).then(groups => {
@@ -146,6 +151,7 @@ function generateGroupSetForProject(factoryKey, project, buildOptions, groupsToG
 };
 
 function generateCommentPeriodSetForProject(factoryKey, project, buildOptions, commentPeriodsToGen) {
+  console.debug("commentPeriodsToGen = " + commentPeriodsToGen);
   return new Promise(function(resolve, reject) {
     let customCommentPeriodSettings = { project: factory_helper.ObjectId(project._id) };
     factory.createMany(factoryKey, commentPeriodsToGen, customCommentPeriodSettings, buildOptions).then(commentPeriods => {
@@ -155,15 +161,17 @@ function generateCommentPeriodSetForProject(factoryKey, project, buildOptions, c
 };
 
 function generateCommentSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentsToGen) {
+  console.debug("commentsToGen = " + commentsToGen);
   return new Promise(function(resolve, reject) {
     let customCommentSettings = { commentPeriod: factory_helper.ObjectId(commentPeriod._id) };
-    factory.createMany(factoryKey, commentsToGen, customCommentSettings, buildOptions).then(comments => {
-      resolve(comments);
+    factory.createMany(factoryKey, commentsToGen, customCommentSettings, buildOptions).then(commentPeriodComments => {
+      resolve(commentPeriodComments);
     });
   });
 };
 
 function generateDocumentSetForProject(factoryKey, project, buildOptions, projectDocumentsToGen) {
+  console.debug("projectDocumentsToGen = " + projectDocumentsToGen);
   return new Promise(function(resolve, reject) {
     buildOptions.projectShortName = project.shortName;
     let customDocumentSettings = { documentSource: "PROJECT", project: factory_helper.ObjectId(project._id) };
@@ -174,6 +182,7 @@ function generateDocumentSetForProject(factoryKey, project, buildOptions, projec
 };
 
 function generateDocumentSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentPeriodDocumentsToGen) {
+  console.debug("commentPeriodDocumentsToGen = " + commentPeriodDocumentsToGen);
   return new Promise(function(resolve, reject) {
   buildOptions.generateFiles = "on";
   let projectsPool = (buildOptions.pipeline) ? buildOptions.pipeline.projects : null;
@@ -186,23 +195,25 @@ function generateDocumentSetForCommentPeriod(factoryKey, commentPeriod, buildOpt
   });
 };
 
-function generateRecentActivitiesSetForProjectDocument(factoryKey, projectDocument, buildOptions, commentPeriodDocumentsToGen) {
+function generateRecentActivitiesSetForProjectDocument(factoryKey, projectDocument, buildOptions, projectDocumentRecentActivitiesToGen) {
+  console.debug("projectDocumentRecentActivitiesToGen = " + projectDocumentRecentActivitiesToGen);
   return new Promise(function(resolve, reject) {
-  let customDocumentSettings = { documentUrl: "/api/document/" + projectDocument._id + "/fetch", contentUrl: "", project: factory_helper.ObjectId(projectDocument.project), pcp: null };  // note that the document._comment field actually refers to a commentPeriod id
-    factory.createMany(factoryKey, commentPeriodDocumentsToGen, customDocumentSettings, buildOptions).then(documents => {
-      resolve(documents);
+  let customRecentActivitySettings = { documentUrl: "/api/document/" + projectDocument._id + "/fetch", contentUrl: "", project: factory_helper.ObjectId(projectDocument.project), pcp: null };
+    factory.createMany(factoryKey, projectDocumentRecentActivitiesToGen, customRecentActivitySettings, buildOptions).then(recentActivities => {
+      resolve(recentActivities);
     });
   });
 };
 
-function generateRecentActivitiesSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentPeriodDocumentsToGen) {
+function generateRecentActivitiesSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentPeriodRecentActivitiesToGen) {
+  console.debug("commentPeriodRecentActivitiesToGen = " + commentPeriodRecentActivitiesToGen);
   return new Promise(function(resolve, reject) {
   let projectsPool = (buildOptions.pipeline) ? buildOptions.pipeline.projects : null;
   const parentProject = projectsPool.filter(project => commentPeriod.project == project.id);
   let contentUrl = (1 == parentProject.length) ? "/p/" + parentProject.shortName + "/commentperiod/" + commentPeriod._id + "" : "";
-  let customDocumentSettings = { documentUrl: "", contentUrl: contentUrl, project: null, pcp: factory_helper.ObjectId(commentPeriod._id) };  // note that the document._comment field actually refers to a commentPeriod id
-    factory.createMany(factoryKey, commentPeriodDocumentsToGen, customDocumentSettings, buildOptions).then(documents => {
-      resolve(documents);
+  let customRecentActivitySettings = { documentUrl: "", contentUrl: contentUrl, project: null, pcp: factory_helper.ObjectId(commentPeriod._id) };
+    factory.createMany(factoryKey, commentPeriodRecentActivitiesToGen, customRecentActivitySettings, buildOptions).then(recentActivities => {
+      resolve(recentActivities);
     });
   });
 };
@@ -213,28 +224,34 @@ function generateProjects(usersData) {
       let numOfProjsToGen = genSettings.projects;
       let numOfProjsGenned = 0;
       if (isNaN(numOfProjsToGen)) numOfProjsToGen = test_helper.defaultNumberOfProjects;
-      console.log('Generating ' + numOfProjsToGen + ' projects.');
+      console.info('Generating ' + numOfProjsToGen + ' projects.');
+      console.debug("documentFactory.MinioControllerBucket = " + documentFactory.MinioControllerBucket);
 
       factory.create(auditFactory.name, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.audit)}).then(audit =>{
+        audit = normalizeFactoryResults(audit);
         factory.createMany(listFactory.name, listFactory.allLists, {faker: getSeeded(genSettings.generate_consistent_data, uss.list)}).then(lists => {
-          factory.createMany(organizationFactory.name, generatorCeilings.organizations, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.organization)}).then(orgsArray => {
-            factory.createMany(userFactory.name, usersData, {faker: getSeeded(genSettings.generate_consistent_data, uss.guaranteedUser), orgsPool: orgsArray}).then(guaranteedUsersArray => {
-                factory.createMany(userFactory.name, generatorCeilings.extraUsers, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.extraUser), orgsPool: orgsArray}).then(extraUsersArray => {
-                let users = guaranteedUsersArray.concat(extraUsersArray);
-                  factory.createMany(projectFactory.name, numOfProjsToGen, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.project), usersPool: users, listsPool: lists, orgsPool: orgsArray}).then(projectsArray => {
+          lists = normalizeFactoryResults(lists);
+          factory.createMany(organizationFactory.name, generatorCeilings.organizations, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.organization)}).then(organizations => {
+            organizations = normalizeFactoryResults(organizations);
+            factory.createMany(userFactory.name, usersData, {faker: getSeeded(genSettings.generate_consistent_data, uss.guaranteedUser), orgsPool: organizations}).then(guaranteedUsersArray => {
+              guaranteedUsersArray = normalizeFactoryResults(guaranteedUsersArray);
+                factory.createMany(userFactory.name, generatorCeilings.extraUsers, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.extraUser), orgsPool: organizations}).then(extraUsersArray => {
+                  extraUsersArray = normalizeFactoryResults(extraUsersArray);
+                  let users = guaranteedUsersArray.concat(extraUsersArray);
+                  factory.createMany(projectFactory.name, numOfProjsToGen, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.project), usersPool: users, listsPool: lists, orgsPool: organizations}).then(projectsArray => {
                     numOfProjsGenned = projectsArray.length;
                     let pipeline = new gd.GeneratedData();
                     pipeline.audit = audit;
                     pipeline.lists = lists;
+                    pipeline.organizations = organizations;
                     pipeline.users = users;
-                    pipeline.organizations = orgsArray;
                     pipeline.projects = projectsArray;
                     resolve(pipeline);
                 }).catch(error => {
                     console.log("Project error:" + error);
                     reject(error);
                 }).finally(function(){
-                    console.log('Generated ' + numOfProjsGenned + ' projects.');
+                    console.info('Generated ' + numOfProjsGenned + ' projects.');
                 });
               });
             });
@@ -248,20 +265,31 @@ function generateProjects(usersData) {
 
 // lightweight for when access to previously generated users and lists is only required
 function generateChildSets(parents, usersPool, listsPool, factoryTemplate) {
-  if (0 == parents.length) return new Promise(function(resolve, reject) { resolve([]); });
+  let emptyPromise = new Promise(function(resolve, reject) { resolve([]); });
+  if (0 == parents.length) return emptyPromise;
   return new Promise(function(resolve, reject) {
     test_helper.dataGenerationSettings.then(genSettings => {
-      let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, factoryTemplate.seed), usersPool: usersPool, listsPool: listsPool}
-      let childGenerationPromises = parents.map(parent => {
-        return generateChildSet(parent, buildOptions, factoryTemplate);
-      });
+      let childGenerationPromises = [emptyPromise];
+      try{
+        childGenerationPromises = parents.map(parent => {
+          console.debug(factoryTemplate.factoryKey + " parent._id='" + parent._id.toString() + "'");
+          let deterministicSeed = faker.seed(generateDeterministicSeed(factoryTemplate.seed, parent._id));
+          console.debug(factoryTemplate.factoryKey + " deterministicSeed=" + deterministicSeed);
+          let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, deterministicSeed), usersPool: usersPool, listsPool: listsPool}
+          return generateChildSet(parent, buildOptions, factoryTemplate);
+        });
+      } catch (e) {
+        console.debug(factoryTemplate.factoryKey + " typeof parent='" + typeof parent + "'");
+        console.debug(factoryTemplate.factoryKey + " parents.length'" + parents.length + "'");
+        console.debug(factoryTemplate.factoryKey + " all parents ='" + parents + "'");
+      }
       resolve(Promise.all(childGenerationPromises));
     });
   }).catch(error => {
-    console.log(factoryTemplate.factoryKey + "s error:" + error);
+    console.info(factoryTemplate.factoryKey + "s error:" + error);
     reject(error);
   }).finally(function(){
-    console.log("Generated all " + factoryTemplate.factoryKey + " sets.");
+    console.info("Generated all " + factoryTemplate.factoryKey + " sets.");
   });
 };
 
@@ -270,24 +298,42 @@ function generateChildSetsUsingPipeline(parents, pipeline, factoryTemplate) {
   if (0 == parents.length) return new Promise(function(resolve, reject) { resolve([]); });
   return new Promise(function(resolve, reject) {
     test_helper.dataGenerationSettings.then(genSettings => {
-      let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, factoryTemplate.seed), pipeline: pipeline}
-      let childGenerationPromises = parents.map(parent => {
-      return generateChildSet(parent, buildOptions, factoryTemplate);
-    });
-      resolve(Promise.all(childGenerationPromises));
+      try{
+        let childGenerationPromises = parents.map(parent => {
+          try{
+            console.debug(factoryTemplate.factoryKey + " parent._id='" + parent._id.toString() + "'");
+            let deterministicSeed = faker.seed(generateDeterministicSeed(factoryTemplate.seed, parent._id));
+            console.debug(factoryTemplate.factoryKey + " deterministicSeed=" + deterministicSeed);
+            let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, factoryTemplate.seed), pipeline: pipeline};
+            return generateChildSet(parent, buildOptions, factoryTemplate);
+          } catch (e) {
+            console.debug(factoryTemplate.factoryKey + " typeof parent='" + typeof parent + "'");
+            console.debug(factoryTemplate.factoryKey + " parents.length'" + parents.length + "'");
+            console.debug(factoryTemplate.factoryKey + " all parents ='" + parents + "'");
+            console.debug(factoryTemplate.factoryKey + " parent._id lookup. error: " + e + ", parent: " + parent);
+          }
+        });
+        resolve(Promise.all(childGenerationPromises));
+      } catch (g) {
+        console.debug(factoryTemplate.factoryKey + " all parents ='" + parents + "'");
+      }
     });
   }).catch(error => {
-    console.log(factoryTemplate.factoryKey + "s error:" + error);
+    console.info(factoryTemplate.factoryKey + "s error:" + error);
     reject(error);
   }).finally(function(){
-    console.log("Generated all " + factoryTemplate.factoryKey + " sets.");
+    console.info("Generated all " + factoryTemplate.factoryKey + " sets.");
   });
 };
 
 function generateChildSet(parent, buildOptions, factoryTemplate) {
   return new Promise(function(resolve, reject) {
     test_helper.dataGenerationSettings.then(genSettings => {
-      (genSettings.generate_consistent_data) ? faker.seed(factoryTemplate.seed) : faker.seed();
+      if (genSettings.generate_consistent_data) {
+        faker.seed(generateDeterministicSeed(factoryTemplate.seed, parent._id));
+      } else {
+        faker.seed();
+      }
       let childrenToGen = faker.random.number(factoryTemplate.upperBound).valueOf();
       if (0 < childrenToGen) {
         resolve(factoryTemplate.factoryMethod(factoryTemplate.factoryKey, parent, buildOptions, childrenToGen));
@@ -296,10 +342,10 @@ function generateChildSet(parent, buildOptions, factoryTemplate) {
       }
     });
   }).catch(error => {
-    console.log(factoryTemplate.factoryKey + " set generation error:" + error);
+    console.info(factoryTemplate.factoryKey + " set generation error:" + error);
     reject(error);
   }).finally(function(){
-    console.log("Generated " + factoryTemplate.factoryKey + " set.");
+    console.info("Generated " + factoryTemplate.factoryKey + " set.");
   });
 };
 
@@ -307,6 +353,68 @@ function getSeeded(setConstant, seed) {
   return (setConstant) ? (require('faker/locale/en')).seed(seed) : (require('faker/locale/en')).seed();
 };
 
+function normalizeFactoryResults(bumpyArrays) {
+  console.debug("bumpyArrays.length: " + bumpyArrays.length);
+  console.debug("bumpyArrays: " + bumpyArrays);
+  if (!bumpyArrays.filter) {
+    let newArray = [];  // do not inline with next line because it will not work
+    newArray.push(bumpyArrays);
+    console.debug(newArray);
+    return newArray;
+  }
+  if ((!!bumpyArrays) && (Array !== bumpyArrays.constructor)) {
+    let newArray = [];  // do not inline with next line because it will not work
+    newArray.push(bumpyArrays);
+    console.debug(newArray);
+    return newArray;
+  }
+  let populatedEntries = bumpyArrays.filter(result => (result));
+  let directResults = populatedEntries.filter(result => result.hasOwnProperty('_id'));  //0
+  console.debug("directResults.length: " + directResults.length);
+  let arraysOfResults = populatedEntries.filter(result => !result.hasOwnProperty('_id'));  //84
+  console.debug("arraysOfResults.length: " + arraysOfResults.length);
+  let normalizedResults = [];
+  try {
+    if (directResults) if (0 < directResults.length) normalizedResults = directResults;
+    if (arraysOfResults) if (0 < arraysOfResults.length) {
+      arraysOfResults.map(test => {
+        if (test.hasOwnProperty('_id')) {
+          console.debug("arraysOfResults.test = " + test);
+          normalizedResults.push(test);
+        } else {
+          console.debug("arraysOfResults.test -> normalizeFactoryResults() with : " + test);
+          normalizeFactoryResults(test).map(result => normalizedResults.push(result));
+        }
+      });
+    }
+  } catch (e) {
+    console.log("error: " + e);
+    console.log("errorstate.directResults.length: " + arraysOfResults.length);
+    console.log("errorstate.directResults: " + directResults);
+    console.log("errorstate.arraysOfResults.length: " + arraysOfResults.length);
+    console.log("errorstate.arraysOfResults: " + arraysOfResults);
+  }
+  console.debug("normalizedResults.length = " + normalizedResults.length);
+  return normalizedResults;
+}
+
+console.debug = function(/* ...args */) {
+    if (isDebugMode) {
+        var vargs = Array.prototype.slice.call(arguments);
+        console.log.apply(this, vargs);
+    }
+};
+
+console.info = function(/* ...args */) {
+    if (isInfoMode) {
+        var vargs = Array.prototype.slice.call(arguments);
+        console.log.apply(this, vargs);
+    }
+};
+
 exports.uss = uniqueStaticSeeds; // external shorthand alias for brevity
 exports.generateEntireDatabase = generateEntireDatabase;
-;
+exports.debug = console.debug;
+exports.isDebugMode = isDebugMode;
+exports.info = console.info;
+exports.isInfoMode = isInfoMode;

--- a/api/test/generate_helper.js
+++ b/api/test/generate_helper.js
@@ -273,7 +273,7 @@ function generateChildSets(parents, usersPool, listsPool, factoryTemplate) {
       try{
         childGenerationPromises = parents.map(parent => {
           console.debug(factoryTemplate.factoryKey + " parent._id='" + parent._id.toString() + "'");
-          let deterministicSeed = faker.seed(generateDeterministicSeed(factoryTemplate.seed, parent._id));
+          let deterministicSeed = factory_helper.generateDeterministicSeed(factoryTemplate.seed, parent._id);
           console.debug(factoryTemplate.factoryKey + " deterministicSeed=" + deterministicSeed);
           let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, deterministicSeed), usersPool: usersPool, listsPool: listsPool}
           return generateChildSet(parent, buildOptions, factoryTemplate);
@@ -302,7 +302,7 @@ function generateChildSetsUsingPipeline(parents, pipeline, factoryTemplate) {
         let childGenerationPromises = parents.map(parent => {
           try{
             console.debug(factoryTemplate.factoryKey + " parent._id='" + parent._id.toString() + "'");
-            let deterministicSeed = faker.seed(generateDeterministicSeed(factoryTemplate.seed, parent._id));
+            let deterministicSeed = factory_helper.generateDeterministicSeed(factoryTemplate.seed, parent._id);
             console.debug(factoryTemplate.factoryKey + " deterministicSeed=" + deterministicSeed);
             let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, factoryTemplate.seed), pipeline: pipeline};
             return generateChildSet(parent, buildOptions, factoryTemplate);
@@ -330,7 +330,8 @@ function generateChildSet(parent, buildOptions, factoryTemplate) {
   return new Promise(function(resolve, reject) {
     test_helper.dataGenerationSettings.then(genSettings => {
       if (genSettings.generate_consistent_data) {
-        faker.seed(generateDeterministicSeed(factoryTemplate.seed, parent._id));
+        let deterministicSeed = factory_helper.generateDeterministicSeed(factoryTemplate.seed, parent._id);
+        faker.seed(deterministicSeed)
       } else {
         faker.seed();
       }

--- a/api/test/generate_helper.js
+++ b/api/test/generate_helper.js
@@ -354,6 +354,8 @@ function getSeeded(setConstant, seed) {
   return (setConstant) ? (require('faker/locale/en')).seed(seed) : (require('faker/locale/en')).seed();
 };
 
+// the factories return all kinds of array nesting and for our generation usage we wish to deal with straight arrays 
+// that we can easily run map functions on.  flatten out any nested arrays factory-girl gives us.
 function normalizeFactoryResults(bumpyArrays) {
   console.debug("bumpyArrays.length: " + bumpyArrays.length);
   console.debug("bumpyArrays: " + bumpyArrays);

--- a/api/test/generated_data.js
+++ b/api/test/generated_data.js
@@ -18,6 +18,24 @@ class GeneratedData {
         this.commentPeriodRecentActivities = null;
         this.groups = null;
     }
+
+    report() {
+        console.log('\n\n \
+******* Generation Statistics *******\n \
+*   ' + ((null == this.audit) ? 0 : this.audit.length) + ' Audits\n \
+*   ' + ((null == this.lists) ? 0 : this.lists.length) + ' Lists\n \
+*   ' + ((null == this.users) ? 0 : this.users.length) + ' Users\n \
+*   ' + ((null == this.organizations) ? 0 : this.organizations.length) + ' Organizations\n \
+*   ' + ((null == this.groups) ? 0 : this.groups.length) + ' Groups\n \
+*   ' + ((null == this.projects) ? 0 : this.projects.length) + ' Projects\n \
+*   ' + ((null == this.projectDocuments) ? 0 : this.projectDocuments.length) + ' Project Documents\n \
+*   ' + ((null == this.projectDocumentRecentActivities) ? 0 : this.projectDocumentRecentActivities.length) + ' Project Document Recent Activities\n \
+*   ' + ((null == this.commentPeriods) ? 0 : this.commentPeriods.length) + ' Comment Periods\n \
+*   ' + ((null == this.commentPeriodComments) ? 0 : this.commentPeriodComments.length) + ' Comment Period Comments\n \
+*   ' + ((null == this.commentPeriodDocuments) ? 0 : this.commentPeriodDocuments.length) + ' Comment Period Documents\n \
+*   ' + ((null == this.commentPeriodRecentActivities) ? 0 : this.commentPeriodRecentActivities.length) + ' Comment Period Recent Activities\n \
+*************************************\n\n');
+    }
 }
 
 module.exports.GeneratedData = GeneratedData;

--- a/api/test/model_change_watcher_hash.json
+++ b/api/test/model_change_watcher_hash.json
@@ -84,7 +84,7 @@
     },
     {
       "name": "document_factory.js",
-      "hash": "8AD5X8aHp3N0vQQk6QAM0FXZmyk="
+      "hash": "BTB4ChYpiS7wqm9ViI9OvgbEuTY="
     },
     {
       "name": "group_factory.js",
@@ -104,7 +104,7 @@
     },
     {
       "name": "list_factory.js",
-      "hash": "Rrrmgw36gCJOFg5sErDHFVHxpQM="
+      "hash": "6XvJFz6lWK9xAewEXfumyYt37+Q="
     },
     {
       "name": "notification_project_factory.js",
@@ -124,7 +124,7 @@
     },
     {
       "name": "recent_activity_factory.js",
-      "hash": "voVWSdxcyg21kHh6gVBC7SNXV4Q="
+      "hash": "drCPHKQHjlFP0LpSim08elmuILk="
     },
     {
       "name": "user_factory.js",

--- a/api/test/test_helper.js
+++ b/api/test/test_helper.js
@@ -57,7 +57,6 @@ afterEach(done => {
 });
 
 afterAll(async () => {
-  console.log("here8");
   let genSettings = await dataGenerationSettings;
   console.log("afterAll:: genSettings = " + genSettings);
   console.log("afterAll:: mongoose.connection = " + mongoose.connection);

--- a/api/test/test_helper.js
+++ b/api/test/test_helper.js
@@ -26,7 +26,7 @@ beforeAll(async () => {
   if (2 < genSettings.projects) jest.setTimeout(5000 * genSettings.projects);
   if (!genSettings.save_to_persistent_mongo) mongoServer = instantiateInMemoryMongoServer();
   await mongooseConnect();
-  if (genSettings.generate) await checkMigrations(runMigrations);
+  if ((genSettings.generate) && (genSettings.save_to_persistent_mongo)) await checkMigrations(runMigrations);
 });
 
 beforeEach(async () => {
@@ -35,24 +35,36 @@ beforeEach(async () => {
 
 afterEach(done => {
   dataGenerationSettings.then(genSettings => {
+    console.log("afterEach:: genSettings = " + genSettings);
+    console.log("afterEach:: mongoose.connection = " + mongoose.connection);
     if (mongoose.connection && mongoose.connection.db) {
+      console.log("afterEach:: mongoose.connection = " + mongoose.connection);
       if (!genSettings.save_to_persistent_mongo) {
+        console.log("afterEach:: genSettings.save_to_persistent_mongo = " + genSettings.save_to_persistent_mongo);
         dbCleaner.clean(mongoose.connection.db, () => {
+          console.log("afterEach:: ran dbCleaner");
           done();
         });
       } else {
+        console.log("afterEach:: did not run dbCleaner");
         done();
       }
     } else {
+      console.log("afterEach:: did not enter mongoose dbCleaner branch");
       done();
     }
   });
 });
 
 afterAll(async () => {
+  console.log("here8");
   let genSettings = await dataGenerationSettings;
+  console.log("afterAll:: genSettings = " + genSettings);
+  console.log("afterAll:: mongoose.connection = " + mongoose.connection);
   if (mongoose.connection) await mongoose.disconnect();
+  console.log("afterAll:: mongoServer = " + mongoServer);
   if ((mongoServer) && (!genSettings.save_to_persistent_mongo)) await mongoServer.stop();
+  console.log("afterAll:: mongoServer = " + mongoServer);
 });
 
 function setupAppServer() {
@@ -175,14 +187,16 @@ async function checkMigrations(callback) {
   checkMongoUri();
   let options;
   if ((!_.isEmpty(app_helper.credentials)) 
-   && (!_.isEmpty(app_helper.credentials.db_username)) 
-   && (!_.isEmpty(app_helper.credentials.db_password))) {
+  && (!_.isEmpty(app_helper.credentials.db_username)) 
+  && (!_.isEmpty(app_helper.credentials.db_password))) {
     options = {};
     let auth = {};
     auth.user = app_helper.credentials.db_username;
     auth.password = app_helper.credentials.db_password;
     options.auth = auth;
   }
+  console.log("checkMigrations:: " + mongoUri);
+  console.log("checkMigrations:: " + options);
   MongoClient.connect(mongoUri, options, function(err, db) {
     if (err) console.error(err);
     var dbo = db.db(app_helper.dbName);


### PR DESCRIPTION
Reviewer note that api/test/generate_helper.js is default collapsed and contains most of the changes.

- created quasi-unique repeatable seeds for static mode, fixing multi-project ObjectID collision bug CWU-149
- flatten nested factory-girl results
- add info & debug level console outputs
- expand PDF generation capabilities (performance still WIP)
- add statistics output

Sample statistics output for `./generate.sh 10 Static Unsaved > output.txt`


     ******* Generation Statistics *******
     *   1 Audits
     *   84 Lists
     *   52 Users
     *   120 Organizations
     *   24 Groups
     *   10 Projects
     *   102 Project Documents
     *   45 Project Document Recent Activities
     *   10 Comment Periods
     *   1335 Comment Period Comments
     *   13 Comment Period Documents
     *   7 Comment Period Recent Activities
     *************************************


Known issues:

- PDF generation performance needs to be further optimized
- Currently does not run on cluster in either Unsaved (Mockgoose) or Saved (mongodb) modes